### PR TITLE
Add individual headers for each module. Fix compile warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ DEPS = $(patsubst %,$(IDIR)/%,$(_DEPS))
 
 _OBJ = \
 	buffer.o \
-	input_queue.o \
 	key_stack.o \
 	line_ends.o \
 	pager.o \

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -1,0 +1,28 @@
+#ifndef BUFFER_H
+#define BUFFER_H
+
+#include <locale.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <sys/wait.h>
+
+#include "line_ends.h"
+#include "stream.h"
+#include "tokenizer.h"
+
+typedef struct {
+  pid_t pid;
+  int fd;
+  Stream *stream;
+  LineEnds *line_ends;
+
+  pthread_t fill_thread;
+  pthread_mutex_t lock;
+} Buffer;
+
+Buffer *new_buffer(pid_t pid, int fd);
+void free_buffer(Buffer *b);
+void *fill_buffer(void *bptr);
+char **get_buffer_lines(Buffer *b, size_t start, size_t num);
+
+#endif

--- a/include/key_stack.h
+++ b/include/key_stack.h
@@ -1,0 +1,22 @@
+#ifndef KEY_STACK_H
+#define KEY_STACK_H
+
+#include <stdlib.h>
+#include "strbuf.h"
+
+typedef struct KeyStackItem KeyStackItem;
+struct KeyStackItem {
+  char *key;
+  KeyStackItem *next;
+};
+
+typedef struct {
+  KeyStackItem *first;
+  KeyStackItem *last;
+} KeyStack;
+
+KeyStack *new_key_stack();
+void key_stack_push(KeyStack *ks, char *key);
+void key_stack_to_strbuf(KeyStack *ks, Strbuf *out);
+
+#endif

--- a/include/line_ends.h
+++ b/include/line_ends.h
@@ -1,0 +1,17 @@
+#ifndef LINE_ENDS_H
+#define LINE_ENDS_H
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  size_t *offsets;
+  size_t len;
+  size_t size;
+} LineEnds;
+
+LineEnds *new_line_ends();
+void free_line_ends(LineEnds *le);
+void push_line_end(LineEnds *le, size_t offset);
+
+#endif

--- a/include/pager.h
+++ b/include/pager.h
@@ -1,0 +1,20 @@
+#ifndef PAGER_H
+#define PAGER_H
+
+#include <ncurses.h>
+#include <unistd.h>
+#include "buffer.h"
+
+typedef struct {
+  char *cmd;
+  Buffer *buffer;
+  int scroll;
+  int cursor;
+} Pager;
+
+Pager *new_pager(char* cmd);
+void free_pager(Pager *p);
+void render_pager(Pager *p);
+void run_pager_command(Pager *p);
+
+#endif

--- a/include/rat.h
+++ b/include/rat.h
@@ -1,124 +1,13 @@
 #ifndef RAT_H
 #define RAT_H
 
-#include <fcntl.h>
 #include <errno.h>
-#include <locale.h>
-#include <ncurses.h>
-#include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include <fcntl.h>
+#include <getopt.h>
 #include <poll.h>
-#include <sys/wait.h>
 
-typedef struct {
-  char *str;
-  size_t len;
-  size_t size;
-} Strbuf;
-
-Strbuf *new_strbuf(char *str);
-void free_strbuf(Strbuf *strbuf);
-void strbuf_write(Strbuf *strbuf, char *str);
-
-typedef struct KeyStackItem KeyStackItem;
-struct KeyStackItem {
-  char *key;
-  KeyStackItem *next;
-};
-
-typedef struct {
-  KeyStackItem *first;
-  KeyStackItem *last;
-} KeyStack;
-
-KeyStack *new_key_stack();
-void key_stack_push(KeyStack *ks, char *key);
-void key_stack_to_strbuf(KeyStack *ks, Strbuf *out);
-
-typedef enum {
-  TK_NONE = 0,
-  TK_CONTENT,
-  TK_NEWLINE,
-  TK_TERMSTYLE,
-} TokenType;
-
-typedef struct {
-  TokenType type;
-  Strbuf *value;
-} Token;
-
-typedef struct {
-  int fd;
-  char unread_byte;
-  int was_unread;
-} Tokenizer;
-
-Tokenizer *new_tokenizer(int fd);
-void free_tokenizer(Tokenizer *tr);
-ssize_t read_byte(Tokenizer *tr, char *byte);
-int unread_byte(Tokenizer *tr, char *byte);
-ssize_t read_token(Tokenizer *tr, Token *t);
-
-typedef struct {
-  Strbuf *strbuf;
-  int closed;
-  pthread_cond_t cond;
-  pthread_mutex_t lock;
-} Stream;
-
-Stream *new_stream();
-void free_stream(Stream *stream);
-void stream_write(Stream *stream, char *buf);
-size_t stream_close(Stream *stream);
-
-typedef struct {
-  Stream *stream;
-  size_t offset;
-} StreamReader;
-
-StreamReader *new_stream_reader(Stream *stream);
-void free_stream_reader(StreamReader *sr);
-size_t stream_reader_read(StreamReader *sr, char *buf, size_t nbyte);
-
-typedef struct {
-  size_t *offsets;
-  size_t len;
-  size_t size;
-} LineEnds;
-
-LineEnds *new_line_ends();
-void free_line_ends(LineEnds *le);
-void push_line_end(LineEnds *le, size_t offset);
-
-typedef struct {
-  pid_t pid;
-  int fd;
-  Stream *stream;
-  LineEnds *line_ends;
-
-  pthread_t fill_thread;
-  pthread_mutex_t lock;
-} Buffer;
-
-Buffer *new_buffer(pid_t pid, int fd);
-void free_buffer(Buffer *b);
-void *fill_buffer(void *bptr);
-char **get_buffer_lines(Buffer *b, size_t start, size_t num);
-
-typedef struct {
-  char *cmd;
-  Buffer *buffer;
-  int scroll;
-  int cursor;
-} Pager;
-
-Pager *new_pager(char* cmd);
-void free_pager(Pager *p);
-void render_pager(Pager *p);
-void run_pager_command(Pager *p);
+#include "key_stack.h"
+#include "pager.h"
 
 #endif
 

--- a/include/strbuf.h
+++ b/include/strbuf.h
@@ -1,0 +1,17 @@
+#ifndef STRBUF_H
+#define STRBUF_H
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  char *str;
+  size_t len;
+  size_t size;
+} Strbuf;
+
+Strbuf *new_strbuf(char *str);
+void free_strbuf(Strbuf *strbuf);
+void strbuf_write(Strbuf *strbuf, char *str);
+
+#endif

--- a/include/stream.h
+++ b/include/stream.h
@@ -1,0 +1,28 @@
+#ifndef STREAM_H
+#define STREAM_H
+
+#include <pthread.h>
+#include "strbuf.h"
+
+typedef struct {
+  Strbuf *strbuf;
+  int closed;
+  pthread_cond_t cond;
+  pthread_mutex_t lock;
+} Stream;
+
+Stream *new_stream();
+void free_stream(Stream *stream);
+void stream_write(Stream *stream, char *buf);
+size_t stream_close(Stream *stream);
+
+typedef struct {
+  Stream *stream;
+  size_t offset;
+} StreamReader;
+
+StreamReader *new_stream_reader(Stream *stream);
+void free_stream_reader(StreamReader *sr);
+size_t stream_reader_read(StreamReader *sr, char *buf, size_t nbyte);
+
+#endif

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -1,0 +1,31 @@
+#ifndef TOKENIZER_H
+#define TOKENIZER_H
+
+#include <unistd.h>
+#include "strbuf.h"
+
+typedef enum {
+  TK_NONE = 0,
+  TK_CONTENT,
+  TK_NEWLINE,
+  TK_TERMSTYLE,
+} TokenType;
+
+typedef struct {
+  TokenType type;
+  Strbuf *value;
+} Token;
+
+typedef struct {
+  int fd;
+  char unread_byte;
+  int was_unread;
+} Tokenizer;
+
+Tokenizer *new_tokenizer(int fd);
+void free_tokenizer(Tokenizer *tr);
+ssize_t read_byte(Tokenizer *tr, char *byte);
+int unread_byte(Tokenizer *tr, char *byte);
+ssize_t read_token(Tokenizer *tr, Token *t);
+
+#endif

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1,4 +1,4 @@
-#include "rat.h"
+#include "buffer.h"
 
 Buffer *new_buffer(pid_t pid, int fd) {
   Buffer *b = (Buffer*)malloc(sizeof(Buffer));

--- a/src/key_stack.c
+++ b/src/key_stack.c
@@ -1,4 +1,4 @@
-#include "rat.h"
+#include "key_stack.h"
 
 KeyStack *new_key_stack() {
   KeyStack *ks = (KeyStack*)malloc(sizeof(*ks));

--- a/src/line_ends.c
+++ b/src/line_ends.c
@@ -1,4 +1,4 @@
-#include "rat.h"
+#include "line_ends.h"
 
 LineEnds *new_line_ends() {
   LineEnds *le = (LineEnds*)malloc(sizeof(*le));

--- a/src/pager.c
+++ b/src/pager.c
@@ -1,4 +1,4 @@
-#include "rat.h"
+#include "pager.h"
 
 Pager *new_pager(char *cmd) {
   Pager *p = (Pager*)malloc(sizeof(*p));

--- a/src/pager.c
+++ b/src/pager.c
@@ -50,7 +50,7 @@ void run_pager_command(Pager *p) {
       dup2(fds[1], STDERR_FILENO);
       close(fds[0]);
       close(fds[1]);
-      execl("/bin/zsh", "zsh", "-c", p->cmd);
+      execl("/bin/zsh", "zsh", "-c", p->cmd, NULL);
       perror("execl");
       exit(EXIT_FAILURE);
     default:

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -1,4 +1,4 @@
-#include "rat.h"
+#include "strbuf.h"
 
 Strbuf *new_strbuf(char *str) {
   size_t len = strlen(str);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1,4 +1,4 @@
-#include "rat.h"
+#include "stream.h"
 
 Stream *new_stream() {
   Stream *stream = (Stream*)malloc(sizeof(Stream));

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -1,4 +1,4 @@
-#include "rat.h"
+#include "tokenizer.h"
 
 Tokenizer *new_tokenizer(int fd) {
   Tokenizer *tr = (Tokenizer*)malloc(sizeof(*tr));


### PR DESCRIPTION
First look at the code and I figured I'd take on a chore to clean up the headers for the different module implementations. There are a bunch of reasons why having one big header file isn't ideal.

Its all good if you would prefer to stick with this method but I thought as my first act I would try to convince you otherwise :P

Here are a few reasons I grabbed from http://wiki.c2.com/?OneBigHeaderFile

* It is difficult to analyze or manage dependencies when everything is dependent upon everything in this one file.
* Whenever anything in that one header changes, everything will be recompiled.
* One cannot compile any module without including everything in this header. This makes it harder to write independent UnitTests or to reuse an individual module.
* Multiple developers have to modify the one file concurrently, because that's where everything is, leading to increased potential for merge conflicts, or slowing down people who have to wait for someone else to release a lock on the file.
* Instead of thinking about where things really belong, programmers just keep dumping things into this one file, leading to a BigBallOfMud.
* The namespace for every compilation unit is polluted with everything that is in that one file.